### PR TITLE
django.utils.hashcompat changed to hashlib

### DIFF
--- a/multisite/middleware.py
+++ b/multisite/middleware.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import get_callable
 from django.db.models.signals import pre_save, post_delete, post_init
 from django.http import Http404, HttpResponsePermanentRedirect
-from django.utils.hashcompat import md5_constructor
+from hashlib import md5 as md5_constructor
 
 from .models import Alias
 


### PR DESCRIPTION
django.utils.hashcompat was depricated in django 1.4 and removed from
django 1.6.
