### PR TITLE
Update get_development_alias in middleware.py

### DIFF
--- a/multisite/middleware.py
+++ b/multisite/middleware.py
@@ -61,17 +61,13 @@ class DynamicSiteMiddleware(object):
 
         Development mode is either:
         - Running tests, i.e. manage.py test
-        - Running locally in settings.DEBUG = True, where the hostname is
-          a top-level name, i.e. localhost
+        - Running with settings.DEBUG = True
         """
         # When running tests, django.core.mail.outbox exists and
         # netloc == 'testserver'
         is_testserver = (hasattr(mail, 'outbox') and
                          netloc in ('testserver', 'adminsite.com'))
-        # When using runserver, assume that host will only have one path
-        # component. This covers 'localhost' and your machine name.
-        is_local_debug = (settings.DEBUG and len(netloc.split('.')) == 1)
-        if is_testserver or is_local_debug:
+        if is_testserver or settings.DEBUG:
             try:
                 # Prefer the default SITE_ID
                 site_id = settings.SITE_ID.get_default()


### PR DESCRIPTION
get_development_alias was not catching when the host was 127.0.0.1. Instead of assuming a dev environment will only be ran using a certain hostname format, get_development_alias should just use settings.DEBUG to determine if it's a development environment.
