### PR TITLE
Use default key prefix if multisite key prefix is not set

### DIFF
--- a/multisite/middleware.py
+++ b/multisite/middleware.py
@@ -30,8 +30,12 @@ class DynamicSiteMiddleware(object):
 
         self.cache_alias = getattr(settings, 'CACHE_MULTISITE_ALIAS',
                                    'default')
-        self.key_prefix = getattr(settings, 'CACHE_MULTISITE_KEY_PREFIX',
-                                  '')
+        self.key_prefix = getattr(
+            settings,
+            'CACHE_MULTISITE_KEY_PREFIX',
+            settings.CACHES[self.cache_alias].get('KEY_PREFIX', '')
+        )
+
         self.cache = get_cache(self.cache_alias, KEY_PREFIX=self.key_prefix)
         post_init.connect(self.site_domain_cache_hook, sender=Site,
                           dispatch_uid='multisite_post_init')


### PR DESCRIPTION
Currently multisite looks for CACHE_MULTISITE_KEY_PREFIX in the settings, and defaults to an empty string if it's not found.  This overrides any KEY_PREFIX set in the default cache.  CACHE_MULTISITE_KEY_PREFIX was also incorrectly named CACHE_SITES_KEY_PREFIX in  hacks.py, which meant that the prefix was defaulting to an empty string even if there was a CACHE_MULTISITE_KEY_PREFIX setting.   Changed to get the KEY_PREFIX set in the cache config if CACHE_MULTISITE_KEY_PREFIX is not available.