### PR TITLE
Cleanup site override even if exception occurs

### DIFF
--- a/multisite/threadlocals.py
+++ b/multisite/threadlocals.py
@@ -101,8 +101,10 @@ class SiteID(local):
         """
         site_id_original = self.site_id
         self.set(value)
-        yield self
-        self.site_id = site_id_original
+        try:
+            yield self
+        finally:
+            self.site_id = site_id_original
 
     def set(self, value):
         from django.db.models import Model

--- a/multisite/threadlocals.py
+++ b/multisite/threadlocals.py
@@ -99,10 +99,10 @@ class SiteID(local):
            ...    print settings.SITE_ID
            2
         """
-        site_id = self.site_id
+        site_id_original = self.site_id
         self.set(value)
         yield self
-        self.site_id = site_id
+        self.site_id = site_id_original
 
     def set(self, value):
         from django.db.models import Model


### PR DESCRIPTION
If an exception happens inside `with site_id.override(temp_site_id):`, the `site_id` doesn't get reverted to the original `site_id`. Just need a `finally` block to make sure it does.
