### PR TITLE
DynamicSiteMiddleware: error out more gracefully in Django 1.8

### DIFF
--- a/multisite/middleware.py
+++ b/multisite/middleware.py
@@ -122,7 +122,7 @@ class DynamicSiteMiddleware(object):
         if callable(fallback):
             view = fallback
         else:
-            view = get_callable(fallback)
+            view = get_callable(fallback, can_fail=True)
             if not callable(view):
                 raise ImproperlyConfigured(
                     'settings.MULTISITE_FALLBACK is not callable: %s' %


### PR DESCRIPTION
In Django 1.8, get_callable raises by default instead of returning the
same string in case of failure. In order to not raise and do our own
error handling, we need to pass can_fail=True to recover the old
behaviour of returning the string in case of failure:

    https://github.com/django/django/commit/91afc00513bd2fa6302ea2be35e1f842cbd5fd38#diff-f83d2617ed57b0c7608c5f5581fa6e7dL81