### PR TITLE
templates: don't error out if template isn't in a particular path

### DIFF
--- a/multisite/template/loaders/filesystem.py
+++ b/multisite/template/loaders/filesystem.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from django.core.exceptions import SuspiciousFileOperation
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.template.loaders.filesystem import Loader as FilesystemLoader
@@ -26,7 +27,7 @@ class Loader(FilesystemLoader):
             except UnicodeDecodeError:
                 # The template dir name was a bytestring that wasn't valid UTF-8.
                 raise
-            except ValueError:
+            except (ValueError, SuspiciousFileOperation):
                 # The joined path was located outside of this particular
                 # template_dir (it might be inside another one, so this isn't
                 # fatal).


### PR DESCRIPTION
Django 1.8 changed what safe_join can raise:

    https://github.com/django/django/commit/b8ba73cd0cb6#diff-3e12401856ca6b30d8d877de2e31cf3aL63

While their intention is for us to catch only SuspiciousFileOperation
and not ValueError, it's relatively safe to catch both and keep
compatibility with both Django 1.6 and 1.8