### PR TITLE
Two more Django 1.9 fixes

### DIFF
--- a/multisite/models.py
+++ b/multisite/models.py
@@ -8,7 +8,11 @@ from django.core.exceptions import ValidationError
 from django.core.validators import validate_ipv4_address
 from django.db import connections, models, router
 from django.db.models import Q
-from django.db.models.signals import pre_save, post_save, post_syncdb
+from django.db.models.signals import pre_save, post_save
+try:
+    from django.db.models.signals import post_migrate
+except ImportError:
+    from django.db.models.signals import post_syncdb as post_migrate
 from django.utils.translation import ugettext_lazy as _
 
 from .hacks import use_framework_for_site_cache
@@ -315,9 +319,15 @@ class Alias(models.Model):
         cls.sync(site=instance)
 
     @classmethod
-    def db_table_created_hook(cls, created_models, *args, **kwargs):
+    def db_table_created_hook(cls, *args, **kwargs):
         """Syncs canonical Alias objects for all existing Site objects."""
-        if cls in created_models:
+        if kwargs.get('created_models'):
+            # For post_syncdb support in Django < 1.7:
+            # As before, only sync_all if Alias was in
+            # the list of created models
+            if cls in kwargs['created_models']:
+                Alias.canonical.sync_all()
+        else:
             Alias.canonical.sync_all()
 
 
@@ -326,4 +336,4 @@ pre_save.connect(Alias.site_domain_changed_hook, sender=Site)
 post_save.connect(Alias.site_created_hook, sender=Site)
 
 # Hook to handle syncdb creating the Alias table
-post_syncdb.connect(Alias.db_table_created_hook)
+post_migrate.connect(Alias.db_table_created_hook)

--- a/multisite/models.py
+++ b/multisite/models.py
@@ -12,6 +12,7 @@ from django.db.models.signals import pre_save, post_save
 try:
     from django.db.models.signals import post_migrate
 except ImportError:
+    # Django < 1.7 compatibility
     from django.db.models.signals import post_syncdb as post_migrate
 from django.utils.translation import ugettext_lazy as _
 

--- a/multisite/tests.py
+++ b/multisite/tests.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import os
 import tempfile
+from unittest import skipUnless, skipIf
 import warnings
 
 
@@ -13,7 +14,6 @@ from django.core.exceptions import (ImproperlyConfigured, SuspiciousOperation,
 from django.http import Http404, HttpResponse
 from django.test import TestCase
 from django.test.client import RequestFactory as DjangoRequestFactory
-from django.utils.unittest import skipUnless, skipIf
 
 from hacks import use_framework_for_site_cache
 


### PR DESCRIPTION
* `django.utils.unittest` was removed in favour of `unittest` from the standard library
* `post_syncdb` signal was removed in favour of `post_migrate`