### PR TITLE
Change return type of get_template_sources() in filesystem loader

### DIFF
--- a/multisite/template/loaders/filesystem.py
+++ b/multisite/template/loaders/filesystem.py
@@ -37,7 +37,7 @@ class Loader(FilesystemLoader):
                 # The joined path was located outside of this particular
                 # template_dir (it might be inside another one, so this isn't
                 # fatal).
-                pass
+                continue
 
             # Template loading was changed in Django 1.9, and
             # django now expects an Origin object to be returned

--- a/multisite/template/loaders/filesystem.py
+++ b/multisite/template/loaders/filesystem.py
@@ -4,6 +4,11 @@ from __future__ import unicode_literals
 from django.core.exceptions import SuspiciousFileOperation
 from django.conf import settings
 from django.contrib.sites.models import Site
+try:
+    from django.template import Origin
+except ImportError:
+    # Django < 1.9
+    pass
 from django.template.loaders.filesystem import Loader as FilesystemLoader
 from django.utils._os import safe_join
 
@@ -24,7 +29,7 @@ class Loader(FilesystemLoader):
 
         for template_dir in new_template_dirs:
             try:
-                yield safe_join(template_dir, template_name)
+                name = safe_join(template_dir, template_name)
             except UnicodeDecodeError:
                 # The template dir name was a bytestring that wasn't valid UTF-8.
                 raise
@@ -33,3 +38,14 @@ class Loader(FilesystemLoader):
                 # template_dir (it might be inside another one, so this isn't
                 # fatal).
                 pass
+
+            # Template loading was changed in Django 1.9, and
+            # django now expects an Origin object to be returned
+            try:
+                yield Origin(
+                    name=name,
+                    template_name=template_name,
+                    loader=self
+                )
+            except NameError:
+                yield name

--- a/multisite/template/loaders/filesystem.py
+++ b/multisite/template/loaders/filesystem.py
@@ -7,8 +7,9 @@ from django.contrib.sites.models import Site
 try:
     from django.template import Origin
 except ImportError:
-    # Django < 1.9
-    pass
+    # Django < 1.9 only expects the name string, not an Origin object
+    def Origin(name="", *args, **kwargs):
+        return name
 from django.template.loaders.filesystem import Loader as FilesystemLoader
 from django.utils._os import safe_join
 
@@ -39,13 +40,8 @@ class Loader(FilesystemLoader):
                 # fatal).
                 continue
 
-            # Template loading was changed in Django 1.9, and
-            # django now expects an Origin object to be returned
-            try:
-                yield Origin(
-                    name=name,
-                    template_name=template_name,
-                    loader=self
-                )
-            except NameError:
-                yield name
+            yield Origin(
+                name=name,
+                template_name=template_name,
+                loader=self
+            )


### PR DESCRIPTION
Django has changed some template loading code in 1.9, and it's now expected that a django.template.Origin object is returned from get_template_sources()

I've based get_template_sources() on the new 1.9 version of django.template.loaders.filesystem.Loader.get_template_sources()