### PR TITLE
Fix a 'unique constraint' exception raised during tests

### DIFF
--- a/multisite/tests.py
+++ b/multisite/tests.py
@@ -726,6 +726,7 @@ class AliasTest(TestCase):
         site.domain = ''
         self.assertRaises(Alias.MultipleObjectsReturned, site.save)
         Alias.aliases.all().delete()
+        Site.objects.get(domain='').delete()  # domain is unique in Django1.9
         site.save()
         self.assertFalse(Alias.objects.filter(site=site).exists())
         # Change Site from an empty domain name


### PR DESCRIPTION
Django 1.9 has made the `domain` field of Sites unique. This
was causing an exception when trying to save a second site
with a blank domain in AliasTest.test_hooks.