### PR TITLE
Prefer settings.TEMPLATES for newer Django versions (fixes #24)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,24 @@ Replace your SITE_ID in settings.py to::
     from multisite import SiteID
     SITE_ID = SiteID()
 
-Add to settings.py TEMPLATE_LOADERS::
+Add to your settings.py TEMPLATES loaders in the OPTIONS section::
+
+    TEMPLATES = [
+        ...
+        {
+            ...
+            'OPTIONS': {
+                'loaders': (
+                    'multisite.template_loader.Loader',
+                    'django.template.loaders.app_directories.Loader',
+                )
+            }
+            ...
+        }
+        ...
+    ]
+
+Or for Django 1.7 and earlier, add to settings.py TEMPLATES_LOADERS::
 
     TEMPLATE_LOADERS = ( 
         'multisite.template_loader.Loader',

--- a/multisite/template/loaders/filesystem.py
+++ b/multisite/template/loaders/filesystem.py
@@ -17,7 +17,13 @@ from django.utils._os import safe_join
 class Loader(FilesystemLoader):
     def get_template_sources(self, template_name, template_dirs=None):
         if not template_dirs:
-            template_dirs = settings.TEMPLATE_DIRS
+            try:
+                template_dirs = [tdir
+                                 for tmpl in settings.TEMPLATES
+                                 for tdir in tmpl['DIRS']]
+            except AttributeError:
+                # Older Django, no settings.TEMPLATES?
+                template_dirs = settings.TEMPLATE_DIRS
 
         domain = Site.objects.get_current().domain
         default_dir = getattr(settings, 'MULTISITE_DEFAULT_TEMPLATE_DIR', 'default')


### PR DESCRIPTION
Django 1.8 has deprecated all of the TEMPLATE_ variables.

    https://docs.djangoproject.com/en/dev/releases/1.8/#template-related-settings