### PR TITLE
Avoid template loader details for better django version compatibility.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,24 @@ Replace your SITE_ID in settings.py to::
     from multisite import SiteID
     SITE_ID = SiteID()
 
-Add to settings.py TEMPLATE_LOADERS::
+Add to your settings.py TEMPLATES loaders in the OPTIONS section::
+
+    TEMPLATES = [
+        ...
+        {
+            ...
+            'OPTIONS': {
+                'loaders': (
+                    'multisite.template_loader.Loader',
+                    'django.template.loaders.app_directories.Loader',
+                )
+            }
+            ...
+        }
+        ...
+    ]
+
+Or for Django 1.7 and earlier, add to settings.py TEMPLATES_LOADERS::
 
     TEMPLATE_LOADERS = ( 
         'multisite.template_loader.Loader',

--- a/multisite/template/loaders/filesystem.py
+++ b/multisite/template/loaders/filesystem.py
@@ -1,47 +1,19 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.core.exceptions import SuspiciousFileOperation
+import os
 from django.conf import settings
 from django.contrib.sites.models import Site
-try:
-    from django.template import Origin
-except ImportError:
-    # Django < 1.9 only expects the name string, not an Origin object
-    def Origin(name="", *args, **kwargs):
-        return name
 from django.template.loaders.filesystem import Loader as FilesystemLoader
-from django.utils._os import safe_join
 
 
 class Loader(FilesystemLoader):
     def get_template_sources(self, template_name, template_dirs=None):
-        if not template_dirs:
-            template_dirs = settings.TEMPLATE_DIRS
-
         domain = Site.objects.get_current().domain
-        default_dir = getattr(settings, 'MULTISITE_DEFAULT_TEMPLATE_DIR', 'default')
-
-        new_template_dirs = []
-        for template_dir in template_dirs:
-            new_template_dirs.append(safe_join(template_dir, domain))
-            if default_dir:
-                new_template_dirs.append(safe_join(template_dir, default_dir))
-
-        for template_dir in new_template_dirs:
-            try:
-                name = safe_join(template_dir, template_name)
-            except UnicodeDecodeError:
-                # The template dir name was a bytestring that wasn't valid UTF-8.
-                raise
-            except (ValueError, SuspiciousFileOperation):
-                # The joined path was located outside of this particular
-                # template_dir (it might be inside another one, so this isn't
-                # fatal).
-                continue
-
-            yield Origin(
-                name=name,
-                template_name=template_name,
-                loader=self
-            )
+        default_dir = getattr(settings, 'MULTISITE_DEFAULT_TEMPLATE_DIR',
+                                        'default')
+        for tname in (os.path.join(domain, template_name),
+                      os.path.join(default_dir, template_name)):
+            for item in super(Loader, self).get_template_sources(tname,
+                                                         template_dirs):
+                yield item


### PR DESCRIPTION
Make the template loader more resilient to changes in Django by prepending the domain to the template name and feeding it to the django implementation, rather than reimplementing the loader here.  Fixes #24 (without updating the doc).  Both forward and backward compatible with current Django versions, and a lot simpler.