### PR TITLE
Insert 'default=1' in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Quickstart
 Replace your SITE_ID in settings.py to::
 
     from multisite import SiteID
-    SITE_ID = SiteID()
+    SITE_ID = SiteID(default=1)
 
 Add to your settings.py TEMPLATES loaders in the OPTIONS section::
 


### PR DESCRIPTION
e.g.: For Django-CMS is a default needed. Otherwise:
```
...
  File "/home/jens/PyLucid_env/lib/python3.5/site-packages/cms/utils/conf.py", line 228, in get_languages
    if settings.SITE_ID != hash(settings.SITE_ID):
  File "/home/jens/PyLucid_env/lib/python3.5/site-packages/multisite/threadlocals.py", line 93, in __hash__
    return self.__int__()
  File "/home/jens/PyLucid_env/lib/python3.5/site-packages/multisite/threadlocals.py", line 59, in __int__
    return self.get_default()
  File "/home/jens/PyLucid_env/lib/python3.5/site-packages/multisite/threadlocals.py", line 123, in get_default
    raise ValueError('SITE_ID has not been set.')
ValueError: SITE_ID has not been set.
```