### PR TITLE
Replace deprecated ExtractResult().tld with .suffix

### DIFF
--- a/multisite/middleware.py
+++ b/multisite/middleware.py
@@ -235,7 +235,7 @@ class CookieDomainMiddleware(object):
             return response     # No cookies to edit
 
         parsed = self.tldextract(request.get_host())
-        if not parsed.tld:
+        if not parsed.suffix:
             return response     # IP address or local path
         if not parsed.domain:
             return response     # Only TLD
@@ -248,7 +248,7 @@ class CookieDomainMiddleware(object):
         else:
             subdomains = [''] + subdomains[-self.depth:]
 
-        domain = '.'.join(subdomains + [parsed.domain, parsed.tld])
+        domain = '.'.join(subdomains + [parsed.domain, parsed.suffix])
 
         for morsel in matched:
             morsel['domain'] = domain


### PR DESCRIPTION
`ExtractResult.tld` property was removed in version 2.0rc1 of tldextract and replaced with `ExtractResult.suffix`, so causes an AttributeError with a tldextract version >=2.0rc1.  Older tldextract versions should be OK, as the `.tld` property in older versions returned `.suffix` anyway.