### PR TITLE
rel.to removed in Django 2.0

### DIFF
--- a/multisite/admin.py
+++ b/multisite/admin.py
@@ -66,13 +66,13 @@ class MultisiteChangeList(ChangeList):
         for filter_spec in filter_specs:
             try:
                 try:
-                    rel_to = filter_spec.field.remote_field.to
+                    remote_model = filter_spec.field.remote_field.model
                 except AttributeError:
-                    rel_to = filter_spec.field.rel.to
+                    remote_model = filter_spec.field.rel.to
             except AttributeError:
                 new_filter_specs.append(filter_spec)
                 continue
-            if rel_to is not Site:
+            if remote_model is not Site:
                 new_filter_specs.append(filter_spec)
                 continue
             lookup_choices = frozenset(filter_spec.lookup_choices) & user_sites
@@ -197,15 +197,15 @@ class MultisiteModelAdmin(admin.ModelAdmin):
             sites = user_sites
 
         try:
-            rel_to = db_field.remote_field.to
+            remote_model = db_field.remote_field.model
         except AttributeError:
-            rel_to = db_field.rel.to
-        if hasattr(rel_to, "site"):
-            kwargs["queryset"] = rel_to._default_manager.filter(
+            remote_model = db_field.rel.to
+        if hasattr(remote_model, "site"):
+            kwargs["queryset"] = remote_model._default_manager.filter(
                 site__in=user_sites
             )
-        if hasattr(rel_to, "sites"):
-            kwargs["queryset"] = rel_to._default_manager.filter(
+        if hasattr(remote_model, "sites"):
+            kwargs["queryset"] = remote_model._default_manager.filter(
                 sites__in=user_sites
             )
         if db_field.name == "site" or db_field.name == "sites":
@@ -213,7 +213,7 @@ class MultisiteModelAdmin(admin.ModelAdmin):
         if hasattr(self, "multisite_indirect_foreign_key_path") and \
            db_field.name in self.multisite_indirect_foreign_key_path.keys():
             fkey = self.multisite_indirect_foreign_key_path[db_field.name]
-            kwargs["queryset"] = rel_to._default_manager.filter(
+            kwargs["queryset"] = remote_model._default_manager.filter(
                 **{fkey: user_sites}
             )
 

--- a/multisite/managers.py
+++ b/multisite/managers.py
@@ -84,7 +84,7 @@ class SpanningCurrentSiteManager(managers.CurrentSiteManager):
         """Given a model and the name of a ForeignKey or ManyToManyField column
         as a string, returns the associated model."""
         try:
-            return model._meta.get_field(fieldname).remote_field.to
+            return model._meta.get_field(fieldname).remote_field.model
         except AttributeError:
             return model._meta.get_field(fieldname).rel.to
 

--- a/multisite/managers.py
+++ b/multisite/managers.py
@@ -83,7 +83,10 @@ class SpanningCurrentSiteManager(managers.CurrentSiteManager):
     def _get_related_model(self, model, fieldname):
         """Given a model and the name of a ForeignKey or ManyToManyField column
         as a string, returns the associated model."""
-        return model._meta.get_field_by_name(fieldname)[0].rel.to
+        try:
+            return model._meta.get_field(fieldname).remote_field.to
+        except AttributeError:
+            return model._meta.get_field(fieldname).rel.to
 
 
 class PathAssistedCurrentSiteManager(models.CurrentSiteManager):

--- a/multisite/models.py
+++ b/multisite/models.py
@@ -126,7 +126,10 @@ class CanonicalAliasManager(models.Manager):
     def sync_missing(self):
         """Create missing canonical Alias objects based on Site.domain."""
         aliases = self.get_queryset()
-        sites = self.model._meta.get_field('site').rel.to
+        try:
+            sites = self.model._meta.get_field('site').remote_field.to
+        except AttributeError:
+            sites = self.model._meta.get_field('site').rel.to
         for site in sites.objects.exclude(aliases__in=aliases):
             Alias.sync(site=site)
 

--- a/multisite/models.py
+++ b/multisite/models.py
@@ -127,7 +127,7 @@ class CanonicalAliasManager(models.Manager):
         """Create missing canonical Alias objects based on Site.domain."""
         aliases = self.get_queryset()
         try:
-            sites = self.model._meta.get_field('site').remote_field.to
+            sites = self.model._meta.get_field('site').remote_field.model
         except AttributeError:
             sites = self.model._meta.get_field('site').rel.to
         for site in sites.objects.exclude(aliases__in=aliases):


### PR DESCRIPTION
rel.to is removed in Django 2.0. For backwards compatibility I check first for remote_field (the updated name for the same property) then fall back on .rel.to. .remote_field is supported from Django 1.9+. I also replaced one call to `._meta.get_field_by_name(…)[0]` to `._meta.get_field(…)` as it does the same thing and `get_field_by_name` is no longer supported.