### PR TITLE
Update travis.yml to use xenial 16.04 build env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: xenial
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
SQLite only goes to 3.8.2 on Ubuntu Trusty which is Travis' default env. Newer versions of Django require at least 3.8.3