### PR TITLE
fix test to get tmp folder from OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ eggs
 parts
 MANIFEST
 multisite/*.egg-info
+.coverage
 .tox/
 .pytest_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: xenial
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 

--- a/multisite/tests.py
+++ b/multisite/tests.py
@@ -1060,8 +1060,7 @@ class TemplateLoaderTests(TestCase):
 class UpdatePublicSuffixListCommandTestCase(TestCase):
 
     def setUp(self):
-        self.cache_file = '/tmp/multisite_tld.dat'
-
+        self.cache_file = os.path.join(tempfile.gettempdir(), "multisite_tld.dat")
         # save the tldextract logger output to a buffer to test output
         self.out = StringIO()
         self.logger = logging.getLogger('tldextract')

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ usedevelop = True
 envlist =
     py36-django{2.2,2.1,2.0,1.11}
     py35-django{2.1,2.0,1.11,1.10,1.9,1.8}
-    py34-django{2.0,1.11,1.10,1.9,1.8}
     py27-django{1.11,1.10,1.9,1.8}
 
 [testenv]


### PR DESCRIPTION
test failed if run on macosx because default tmp folder is not /tmp. Consider dropping py3.4