### PR TITLE
Remove deprecated warning with django 3

### DIFF
--- a/multisite/models.py
+++ b/multisite/models.py
@@ -142,7 +142,7 @@ class NotCanonicalAliasManager(models.Manager):
 
     def get_queryset(self):
         qset = super(NotCanonicalAliasManager, self).get_queryset()
-        return qset.filter(is_canonical__isnull=True)
+        return qset.filter(is_canonical=False)
 
 
 def validate_true_or_none(value):
@@ -170,9 +170,9 @@ class Alias(models.Model):
     site = models.ForeignKey(
         Site, related_name='aliases', on_delete=models.CASCADE
     )
-    is_canonical = models.NullBooleanField(
+    is_canonical = models.BooleanField(
         _('is canonical?'),
-        default=None, editable=False,
+        default=False, editable=False,
         validators=[validate_true_or_none],
         help_text=_('Does this domain name match the one in site?'),
     )


### PR DESCRIPTION
Hello,
On Django 3 a warning appears. Here a small commit with correction to avoid it.

I noticed a regression with tldextract==3.0.2 :   
   _middelware.py 245: tldextract.TLDExtract(cache_file=self.psl_cache)_ 
The cache_file option is replaced by cache_dir. 

My work around was to add tldextract==2.2.3 in the requirements.

Best Regards